### PR TITLE
Removing prefs:root since Apple started rejecting apps using non public url schemes.

### DIFF
--- a/ios/CDVBackgroundGeolocation/LocationManager.m
+++ b/ios/CDVBackgroundGeolocation/LocationManager.m
@@ -312,7 +312,8 @@ enum {
 
 - (void) showLocationSettings
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"prefs:root=LOCATION_SERVICES"]];
+    // NOOP - Since Apple started rejecting apps using non public url schemes
+    // https://github.com/mauron85/cordova-plugin-background-geolocation/issues/394
 }
 
 - (NSMutableDictionary*) getStationaryLocation


### PR DESCRIPTION
Removing prefs:root since Apple started rejecting apps using non public url schemes.